### PR TITLE
使用 mobile-forever 适配屏幕，提高桌面端、横屏可访问性

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@rollup/plugin-babel": "^6.0.3",
         "@vitejs/plugin-vue": "^3.2.0",
         "babel-plugin-import": "^1.13.6",
-        "postcss-px-to-viewport": "^1.1.1",
+        "postcss-mobile-forever": "^2.3.3",
         "unplugin-auto-import": "^0.14.2",
         "unplugin-vue-components": "^0.23.0",
         "vite": "^3.0.9"
@@ -2287,15 +2287,6 @@
       "resolved": "https://registry.npmmirror.com/normalize.css/-/normalize.css-8.0.1.tgz",
       "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -2425,14 +2416,13 @@
         "enhanced-resolve": "^4.1.1"
       }
     },
-    "node_modules/postcss-px-to-viewport": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/postcss-px-to-viewport/-/postcss-px-to-viewport-1.1.1.tgz",
-      "integrity": "sha512-2x9oGnBms+e0cYtBJOZdlwrFg/mLR4P1g2IFu7jYKvnqnH/HLhoKyareW2Q/x4sg0BgklHlP1qeWo2oCyPm8FQ==",
+    "node_modules/postcss-mobile-forever": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/postcss-mobile-forever/-/postcss-mobile-forever-2.3.3.tgz",
+      "integrity": "sha512-Zch37T6oxypIQcz/SXHZvEeCGC5Grk0dfMCwY3MGEuRGc1syvvzQKIbAyel+r//45EZlsWzs+Zs5TkCQRAVZ7A==",
       "dev": true,
-      "dependencies": {
-        "object-assign": ">=4.0.1",
-        "postcss": ">=5.0.2"
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -4703,12 +4693,6 @@
       "resolved": "https://registry.npmmirror.com/normalize.css/-/normalize.css-8.0.1.tgz",
       "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
-    },
     "parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -4796,15 +4780,12 @@
         "enhanced-resolve": "^4.1.1"
       }
     },
-    "postcss-px-to-viewport": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/postcss-px-to-viewport/-/postcss-px-to-viewport-1.1.1.tgz",
-      "integrity": "sha512-2x9oGnBms+e0cYtBJOZdlwrFg/mLR4P1g2IFu7jYKvnqnH/HLhoKyareW2Q/x4sg0BgklHlP1qeWo2oCyPm8FQ==",
+    "postcss-mobile-forever": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/postcss-mobile-forever/-/postcss-mobile-forever-2.3.3.tgz",
+      "integrity": "sha512-Zch37T6oxypIQcz/SXHZvEeCGC5Grk0dfMCwY3MGEuRGc1syvvzQKIbAyel+r//45EZlsWzs+Zs5TkCQRAVZ7A==",
       "dev": true,
-      "requires": {
-        "object-assign": ">=4.0.1",
-        "postcss": ">=5.0.2"
-      }
+      "requires": {}
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@rollup/plugin-babel": "^6.0.3",
     "@vitejs/plugin-vue": "^3.2.0",
     "babel-plugin-import": "^1.13.6",
-    "postcss-px-to-viewport": "^1.1.1",
+    "postcss-mobile-forever": "^2.3.3",
     "unplugin-auto-import": "^0.14.2",
     "unplugin-vue-components": "^0.23.0",
     "vite": "^3.0.9"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,10 +1,13 @@
 module.exports = {
     plugins: {
-        "postcss-px-to-viewport": {
-            unitToConvert: "px",
-            viewportWidth: 420, // ��窗的宽度，对应的是我们设计�
+        "postcss-mobile-forever": {
+            rootSelector: '.app',
+            viewportWidth: 420, // 设计稿宽度
+            // maxDisplayWidth: 600, // 视图的最大宽度，超过该宽度则视图居中，视图宽度不变
+            disableLandscape: false, // 关闭横屏适配
+            disableDesktop: false, // 关闭桌面端适配
             // unitPrecision: 6,
             // propList: ['*'],
-        }
+        },
     }
 }


### PR DESCRIPTION
Hello Seven，我看了您的记账本，挺精致。欢迎试下我最近开发的插件，[ppostcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever)，可以做移动端适配，同时适配桌面端和横屏。同时插件还能限制视口单位最大宽度，插件支持 PostCSS 8，所以控制台不会警告版本问题，另外插件也支持传入 viewportWidth 函数，支持动态生成设计视图。
插件也支持 postcss-px-to-viewport 的大部分功能，都通过了单元测试。另外插件持续维护，欢迎使用啊～